### PR TITLE
Enable auto repair when interacting with workbench

### DIFF
--- a/config/valheim_plus.cfg
+++ b/config/valheim_plus.cfg
@@ -610,7 +610,7 @@ restSecondsPerComfortLevel = 60
 deathPenaltyMultiplier = 0
 
 ; If set to true, this option will automatically repair your equipment when you interact with the appropriate workbench.
-autoRepair = false
+autoRepair = true
 
 ; Boss buff duration (seconds)
 guardianBuffDuration = 300


### PR DESCRIPTION
Auto-magically repair your stuff (but still have to go to the suitable workbench).