### PR TITLE
Add mod to increase text input limit on all signs

### DIFF
--- a/config/Atzes.Longer.TextInput.cfg
+++ b/config/Atzes.Longer.TextInput.cfg
@@ -1,0 +1,7 @@
+[MOD-SETTINGS]
+
+## Defines max length for any input text length
+# Setting type: UInt32
+# Default value: 255
+lengthInputText = 255
+

--- a/plugins/Atze's Longer Textinput.dll
+++ b/plugins/Atze's Longer Textinput.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfc5315f9affdbeb660ef9dc6bcbac832d91e2025ad0ee50dcb27e1f36a12e32
+size 8704


### PR DESCRIPTION
Add: [Atze's Longer TextInput](https://www.nexusmods.com/valheim/mods/2839)

Apparently, this applies to all text fields (portal names, pet names, etc) and not just signs.